### PR TITLE
Update appstoreconnectapi to work with PyJWT 2.4

### DIFF
--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -78,8 +78,6 @@ class Api:
 			key = self.key_file
 		self.token_gen_date = datetime.now()
 		exp = int(time.mktime((self.token_gen_date + timedelta(minutes=20)).timetuple()))
-
-		# Prepare token payload and header
 		token_payload = {
 			'iss': self.issuer_id,
 			'exp': exp,
@@ -89,15 +87,12 @@ class Api:
 			'kid': self.key_id,
 			'typ': 'JWT'
 		}
-
-		# Encode the token
 		encoded_token = jwt.encode(
 			payload=token_payload,
 			key=key,
 			algorithm=ALGORITHM,
 			headers=token_headers
 		)
-
 		return encoded_token
 
 	def _get_resource(self, Resource, resource_id):

--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -87,13 +87,12 @@ class Api:
 			'kid': self.key_id,
 			'typ': 'JWT'
 		}
-		encoded_token = jwt.encode(
+		return jwt.encode(
 			payload=token_payload,
 			key=key,
 			algorithm=ALGORITHM,
 			headers=token_headers
 		)
-		return encoded_token
 
 	def _get_resource(self, Resource, resource_id):
 		url = "%s%s/%s" % (BASE_API, Resource.endpoint, resource_id)

--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -76,10 +76,30 @@ class Api:
 			key = open(self.key_file, 'r').read()
 		except IOError as e:
 			key = self.key_file
+
 		self.token_gen_date = datetime.now()
 		exp = int(time.mktime((self.token_gen_date + timedelta(minutes=20)).timetuple()))
-		return jwt.encode({'iss': self.issuer_id, 'exp': exp, 'aud': 'appstoreconnect-v1'}, key,
-						  headers={'kid': self.key_id, 'typ': 'JWT'}, algorithm=ALGORITHM)
+
+		# Prepare token payload and header
+		token_payload = {
+			'iss': self.issuer_id,
+			'exp': exp,
+			'aud': 'appstoreconnect-v1'
+		}
+		token_headers = {
+			'kid': self.key_id,
+			'typ': 'JWT'
+		}
+
+		# Encode the token
+		encoded_token = jwt.encode(
+			payload=token_payload,
+			key=key,
+			algorithm=ALGORITHM,
+			headers=token_headers
+		)
+
+		return encoded_token
 
 	def _get_resource(self, Resource, resource_id):
 		url = "%s%s/%s" % (BASE_API, Resource.endpoint, resource_id)

--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -79,7 +79,7 @@ class Api:
 		self.token_gen_date = datetime.now()
 		exp = int(time.mktime((self.token_gen_date + timedelta(minutes=20)).timetuple()))
 		return jwt.encode({'iss': self.issuer_id, 'exp': exp, 'aud': 'appstoreconnect-v1'}, key,
-		                   headers={'kid': self.key_id, 'typ': 'JWT'}, algorithm=ALGORITHM).decode('ascii')
+						  headers={'kid': self.key_id, 'typ': 'JWT'}, algorithm=ALGORITHM)
 
 	def _get_resource(self, Resource, resource_id):
 		url = "%s%s/%s" % (BASE_API, Resource.endpoint, resource_id)

--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -76,7 +76,6 @@ class Api:
 			key = open(self.key_file, 'r').read()
 		except IOError as e:
 			key = self.key_file
-
 		self.token_gen_date = datetime.now()
 		exp = int(time.mktime((self.token_gen_date + timedelta(minutes=20)).timetuple()))
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ VERSION = None
 
 REQUIRED = [
     'requests>=2.20.1,==2.*',
-    'PyJWT>=1.6.4,==1.*',
+    'PyJWT>=2.4',
     'cryptography>=2.6.1',
 ]
 


### PR DESCRIPTION
This updates `appstoreconnectapi` to work with [PyJWT](https://pyjwt.readthedocs.io/en/stable/) `2.4` and thus fixes the dependency conflict the current version has with the `PyJWT` version needed by the [singer_sdk](https://pypi.org/project/singer-sdk/):

```
$ poetry lock && poetry install
Updating dependencies
Resolving dependencies... (3.2s)

Because no versions of singer-sdk match >0.36.1,<0.37.0
 and singer-sdk (0.36.1) depends on PyJWT (>=2.4,<3.0), singer-sdk (>=0.36.1,<0.37.0) requires PyJWT (>=2.4,<3.0).
And because appstoreconnect (0.10.1) depends on PyJWT (>=1.6.4,<2.dev0)
 and no versions of appstoreconnect match >0.10.1,<0.11.0, singer-sdk (>=0.36.1,<0.37.0) is incompatible with appstoreconnect (>=0.10.1,<0.11.0).
So, because tap-appstore depends on both appstoreconnect (~=0.10.1) and singer-sdk[testing] (~=0.36.1), version solving failed.
```

We need to merge and tag/release this PR in order to ship https://github.com/Automattic/tap-appstore-singer-sdk/pull/1 