### PR TITLE
Fix gzip report downloads: accept content-type, sniff archives, add tests

### DIFF
--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -322,18 +322,23 @@ class Api:
 					data_gz = data_gz + chunk
 
 			# App Store Connect labels report downloads as application/gzip but
-			# may ship either a gzip stream or a zip archive. Sniff magic bytes
-			# instead of trusting the content-type.
-			if data_gz[:2] == b'\x1f\x8b':
-				data = gzip.decompress(data_gz)
-			elif data_gz[:2] == b'PK':
-				with zipfile.ZipFile(io.BytesIO(data_gz)) as zf:
-					names = zf.namelist()
-					if not names:
-						raise APIError("Empty zip archive in report response")
-					data = zf.read(names[0])
+			# ships various nested containers: a bare gzip stream, a zip archive,
+			# or a zip archive whose member is itself gzipped. Unwrap each layer
+			# by sniffing magic bytes instead of trusting the content-type.
+			data = data_gz
+			for _ in range(5):  # guard against pathological nesting
+				if data[:2] == b'\x1f\x8b':            # gzip
+					data = gzip.decompress(data)
+				elif data[:2] == b'PK':                # zip
+					with zipfile.ZipFile(io.BytesIO(data)) as zf:
+						names = zf.namelist()
+						if not names:
+							raise APIError("Empty zip archive in report response")
+						data = zf.read(names[0])
+				else:
+					break
 			else:
-				raise APIError("Unrecognized report archive format: %r" % data_gz[:4])
+				raise APIError("Report archive nested too deeply")
 			return data.decode("utf-8")
 		else:
 			if not 200 <= r.status_code <= 299:

--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -1,6 +1,8 @@
 import requests
 import jwt
 import gzip
+import io
+import zipfile
 import platform
 import hashlib
 from collections import defaultdict
@@ -319,7 +321,19 @@ class Api:
 				if chunk:
 					data_gz = data_gz + chunk
 
-			data = gzip.decompress(data_gz)
+			# App Store Connect labels report downloads as application/gzip but
+			# may ship either a gzip stream or a zip archive. Sniff magic bytes
+			# instead of trusting the content-type.
+			if data_gz[:2] == b'\x1f\x8b':
+				data = gzip.decompress(data_gz)
+			elif data_gz[:2] == b'PK':
+				with zipfile.ZipFile(io.BytesIO(data_gz)) as zf:
+					names = zf.namelist()
+					if not names:
+						raise APIError("Empty zip archive in report response")
+					data = zf.read(names[0])
+			else:
+				raise APIError("Unrecognized report archive format: %r" % data_gz[:4])
 			return data.decode("utf-8")
 		else:
 			if not 200 <= r.status_code <= 299:

--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -312,7 +312,7 @@ class Api:
 				 	payload.get('errors', [])[0].get('status', None)
 				)
 			return payload
-		elif content_type == 'application/a-gzip':
+		elif content_type in ('application/a-gzip', 'application/gzip'):
 			# TODO implement stream decompress
 			data_gz = b""
 			for chunk in r.iter_content(1024 * 1024):

--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -272,6 +272,27 @@ class Api:
 			url = "%s%ssort=%s" % (url, separator, sort)
 		return url
 
+	@staticmethod
+	def _unwrap_report_archive(data, max_depth=5):
+		# App Store Connect labels report downloads as application/gzip but
+		# ships various nested containers: a bare gzip stream, a zip archive,
+		# or a zip archive whose member is itself gzipped. Unwrap each layer
+		# by sniffing magic bytes instead of trusting the content-type.
+		for _ in range(max_depth):  # guard against pathological nesting
+			if data[:2] == b'\x1f\x8b':            # gzip
+				data = gzip.decompress(data)
+			elif data[:2] == b'PK':                # zip
+				with zipfile.ZipFile(io.BytesIO(data)) as zf:
+					names = zf.namelist()
+					if not names:
+						raise APIError("Empty zip archive in report response")
+					data = zf.read(names[0])
+			else:
+				break
+		else:
+			raise APIError("Report archive nested too deeply")
+		return data
+
 	def _api_call(self, url, method=HttpMethod.GET, post_data=None):
 		headers = {"Authorization": "Bearer %s" % self.token}
 		if self._debug:
@@ -315,31 +336,12 @@ class Api:
 				)
 			return payload
 		elif content_type in ('application/a-gzip', 'application/gzip'):
-			# TODO implement stream decompress
 			data_gz = b""
 			for chunk in r.iter_content(1024 * 1024):
 				if chunk:
 					data_gz = data_gz + chunk
 
-			# App Store Connect labels report downloads as application/gzip but
-			# ships various nested containers: a bare gzip stream, a zip archive,
-			# or a zip archive whose member is itself gzipped. Unwrap each layer
-			# by sniffing magic bytes instead of trusting the content-type.
-			data = data_gz
-			for _ in range(5):  # guard against pathological nesting
-				if data[:2] == b'\x1f\x8b':            # gzip
-					data = gzip.decompress(data)
-				elif data[:2] == b'PK':                # zip
-					with zipfile.ZipFile(io.BytesIO(data)) as zf:
-						names = zf.namelist()
-						if not names:
-							raise APIError("Empty zip archive in report response")
-						data = zf.read(names[0])
-				else:
-					break
-			else:
-				raise APIError("Report archive nested too deeply")
-			return data.decode("utf-8")
+			return self._unwrap_report_archive(data_gz).decode("utf-8")
 		else:
 			if not 200 <= r.status_code <= 299:
 				raise APIError("HTTP error [%d][%s]" % (r.status_code, r.content))

--- a/tests/test_unwrap_report_archive.py
+++ b/tests/test_unwrap_report_archive.py
@@ -1,0 +1,72 @@
+import gzip
+import io
+import unittest
+import zipfile
+
+from appstoreconnect.api import Api, APIError
+
+
+def _gzip(data):
+	return gzip.compress(data)
+
+
+def _zip(name, data):
+	buf = io.BytesIO()
+	with zipfile.ZipFile(buf, mode="w") as zf:
+		zf.writestr(name, data)
+	return buf.getvalue()
+
+
+class UnwrapReportArchiveTest(unittest.TestCase):
+
+	def test_plain_bytes_passthrough(self):
+		payload = b"Date\tUnits\n2026-01-01\t5\n"
+		self.assertEqual(Api._unwrap_report_archive(payload), payload)
+
+	def test_bare_gzip(self):
+		payload = b"report contents"
+		self.assertEqual(Api._unwrap_report_archive(_gzip(payload)), payload)
+
+	def test_zip_archive(self):
+		payload = b"report contents"
+		self.assertEqual(Api._unwrap_report_archive(_zip("report.txt", payload)), payload)
+
+	def test_zip_with_gzipped_member(self):
+		payload = b"report contents"
+		archive = _zip("report.txt.gz", _gzip(payload))
+		self.assertEqual(Api._unwrap_report_archive(archive), payload)
+
+	def test_empty_zip_raises(self):
+		buf = io.BytesIO()
+		with zipfile.ZipFile(buf, mode="w"):
+			pass
+		with self.assertRaises(APIError):
+			Api._unwrap_report_archive(buf.getvalue())
+
+	def test_nesting_too_deep_raises(self):
+		data = b"payload"
+		for _ in range(6):  # exceeds default max_depth of 5
+			data = _gzip(data)
+		with self.assertRaises(APIError):
+			Api._unwrap_report_archive(data)
+
+	def test_real_subscription_report_zip_of_gzip(self):
+		# App Store Connect subscription reports are tab-separated text shipped
+		# as a zip archive whose single member is gzip-compressed. Mirror that
+		# nesting and the actual decode path used by _api_call.
+		tsv = (
+			"Start Date\tEnd Date\tApp Name\tApp Apple ID\tSubscription Name\t"
+			"Standard Subscription Duration\tCustomer Price\tActive Standard Price Subscriptions\n"
+			"06/22/2026\t06/22/2026\tDino Rush\t123456789\tDino Rush Pro\t1 Month\t4.99\t1024\n"
+		).encode("utf-8")
+		archive = _zip("S_D_123456789_20260622.txt.gz", _gzip(tsv))
+
+		report = Api._unwrap_report_archive(archive).decode("utf-8")
+
+		self.assertEqual(report, tsv.decode("utf-8"))
+		header = report.splitlines()[0].split("\t")
+		self.assertIn("Active Standard Price Subscriptions", header)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary
App Store Connect labels report downloads as `application/gzip` (or `application/a-gzip`) and ships them in various nested containers — a bare gzip stream, a zip archive, or a zip whose member is itself gzipped. Previously these responses were not decompressed correctly.

This branch:
- Accepts `application/gzip` / `application/a-gzip` content-types for report downloads.
- Unwraps each layer by **sniffing magic bytes** (`1f 8b` gzip, `PK` zip) instead of trusting the content-type, with a depth guard against pathological nesting.
- Extracts the unwrap loop into `Api._unwrap_report_archive` (static method) so it is testable without constructing an `Api` (which requires a signing key).
- Removes the stale `# TODO implement stream decompress` comment — decompression is implemented.

## Tests
Added `tests/test_unwrap_report_archive.py` (stdlib `unittest`, no new deps):
- bare gzip, zip, zip-wrapping-gzip, plain passthrough
- empty-zip and over-nesting error paths
- a realistic subscription report (tab-separated text in zip-of-gzip)

```
$ ./venv/bin/python -m unittest tests.test_unwrap_report_archive
Ran 7 tests in 0.001s
OK
```

## Note
Response is still buffered fully in memory before decompression (not true streaming). True streaming decompress remains a possible future improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)